### PR TITLE
Added redis_unixsocket & redis_unixsocketperm variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,6 @@ redis_maxmemory_policy: volatile-lru
 redis_appendonly: no
 redis_appendfilename: appendonly.aof
 redis_appendfsync: everysec
+
+# redis_unixsocket: /var/run/redis/redis.sock
+# redis_unixsocketperm: 755

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -37,9 +37,13 @@ bind {{ redis_bind }}
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
-#
-# unixsocket /var/run/redis/redis.sock
-# unixsocketperm 755
+{% if redis_unixsocket is defined %}
+unixsocket {{ redis_unixsocket }}
+{% endif %}
+
+{% if redis_unixsocketperm is defined %}
+unixsocketperm {{ redis_unixsocketperm }}
+{% endif %}
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0


### PR DESCRIPTION
Believe or not, but we use them traditionally.
