### PR TITLE
feature: can now change redis uid

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 redis_enabled: yes                      # Enable the role
 redis_service: redis-server             # Name of the redis service
 redis_manage_service: True              # Manage service (start/enabled)
+redis_uid:
 redis_configuration: /etc/redis/redis.conf  # Path to redis configuration
 redis_ppa: ppa:chris-lea/redis-server   # Set blank fot skip adding ppa
 redis_update_kernel: yes                # Set the kernel parameter for vm overcommit

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: set redis user uid
+  user: name=redis uid={{ redis_uid }} state=present
+  when: redis_uid
+
+- name: reset redis folder and subfolder to new uid
+  file: path={{ redis_db_dir }} owner=redis group=redis follow=yes recurse=yes state=directory
+  when: redis_uid
+
 - name: redis-configure | Configure redis
   template: src=redis.conf.j2 dest={{redis_configuration}}
   notify:


### PR DESCRIPTION
Hi,

It can be nice in Cloud or Docker environment to setup persistent disk for redis db. However uid can change and avoid redis to start. Forcing uid permit to make it work anytime.

Can you please merge it and make a new release?

Thanks