### PR TITLE
fix rights when changing uid that avoid service to start

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -5,7 +5,10 @@
   when: redis_uid
 
 - name: reset redis folder and subfolder to new uid
-  file: path={{ redis_db_dir }} owner=redis group=redis follow=yes recurse=yes state=directory
+  file: path={{ item }} owner={{ redis_uid }} group=redis follow=yes recurse=yes state=directory
+  with_items:
+    - "{{ redis_db_dir }}"
+    - /var/log/redis
   when: redis_uid
 
 - name: redis-configure | Configure redis


### PR DESCRIPTION
Hi,

This fix makes service start. There was an issue when changing uid and not log file. If no file permission was given to log folder, then service refuse to start.

Can you please merge and make a new tag for it.

Thanks