### PR TITLE
redis_includes[] with extra config files to include

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,3 +54,6 @@ redis_appendfsync: everysec
 
 # redis_unixsocket: /var/run/redis/redis.sock
 # redis_unixsocketperm: 755
+
+# Extra includes
+redis_includes: []

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -712,3 +712,6 @@ aof-rewrite-incremental-fsync yes
 #
 # include /path/to/local.conf
 # include /path/to/other.conf
+{% for include in redis_includes %}
+include {{ include }}
+{% endfor %}


### PR DESCRIPTION
Allows one to provide partial ``redis.conf`` files to to be included at the end of the main one.

Feature and logic copied over from geerlingguy.redis Ansible Galaxy role (https://github.com/geerlingguy/ansible-role-redis/blob/master/templates/redis.conf.j2#L43)